### PR TITLE
调整了使用七牛SDK惯例

### DIFF
--- a/src/gopher/account.go
+++ b/src/gopher/account.go
@@ -10,7 +10,6 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/gorilla/sessions"
 	"github.com/jimmykuu/wtforms"
-	"github.com/qiniu/api/auth/digest"
 	. "github.com/qiniu/api/conf"
 	qiniu_io "github.com/qiniu/api/io"
 	"github.com/qiniu/api/rs"
@@ -20,6 +19,12 @@ import (
 	"strings"
 	"time"
 )
+
+func init() {
+	//全局初始下即可，当mac为nil时候，会以此为默认
+	ACCESS_KEY = Config.QiniuAccessKey
+	SECRET_KEY = Config.QiniuSecretKey
+}
 
 var defaultAvatars = []string{
 	"gopher_aqua.jpg",
@@ -502,11 +507,6 @@ func changeAvatarHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		extra := &qiniu_io.PutExtra{}
-
-		ACCESS_KEY = Config.QiniuAccessKey
-		SECRET_KEY = Config.QiniuSecretKey
-
 		filenameExtension := ".jpg"
 		if uploadFileType == "image/png" {
 			filenameExtension = ".png"
@@ -526,10 +526,10 @@ func changeAvatarHandler(w http.ResponseWriter, r *http.Request) {
 		err = qiniu_io.Put(
 			nil,
 			ret,
-			policy.Token(&digest.Mac{AccessKey: Config.QiniuAccessKey, SecretKey: []byte(Config.QiniuSecretKey)}),
+			policy.Token(nil),
 			key,
 			formFile,
-			extra,
+			nil,
 		)
 
 		if err != nil {

--- a/src/gravatar2qiniu/gravatar2qiniu.go
+++ b/src/gravatar2qiniu/gravatar2qiniu.go
@@ -24,13 +24,6 @@ func main() {
 	ACCESS_KEY = gopher.Config.QiniuAccessKey
 	SECRET_KEY = gopher.Config.QiniuSecretKey
 
-	extra := &qiniu_io.PutExtra{
-		Bucket:         "gopher",
-		MimeType:       "",
-		CustomMeta:     "",
-		CallbackParams: "",
-	}
-
 	var policy = rs.PutPolicy{
 		Scope: "gopher",
 	}
@@ -61,7 +54,7 @@ func main() {
 
 			buf := bytes.NewBuffer(body)
 
-			err = qiniu_io.Put(nil, ret, policy.Token(), key, buf, extra)
+			err = qiniu_io.Put(nil, ret, policy.Token(nil), key, buf, nil)
 			if err == nil {
 				c.Update(bson.M{"_id": user.Id_}, bson.M{"$set": bson.M{"avatar": filename}})
 				fmt.Printf("upload %s's avatar success: %s\n", user.Email, filename)


### PR DESCRIPTION
简单了调整下，使用七牛SDK惯例，没有做测试。

其实七牛完全支持，从客户端直传，业务服务器分发一个upToken到客户端即可，而不必在自己的业务服务器来上传。不过针对头像这种小文件，这种工作模式优势可能不太明显。
